### PR TITLE
fix: support Mirakurun v4 base image

### DIFF
--- a/src/mirakurun/Dockerfile
+++ b/src/mirakurun/Dockerfile
@@ -5,9 +5,6 @@ FROM chinachu/mirakurun:4.1.3
 ARG DEPENDENCIES="git build-essential libtool autoconf automake cmake"
 RUN <<EOF
     set -eux
-    sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
-    sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
-    sed -i '/buster-updates/d' /etc/apt/sources.list
     apt-get update
     apt-get install -y ${DEPENDENCIES} pkg-config libpcsclite-dev
     # Install recpt1

--- a/src/mirakurun/Dockerfile
+++ b/src/mirakurun/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM chinachu/mirakurun:3.8.0
+FROM chinachu/mirakurun:4.1.3
 
 ARG DEPENDENCIES="git build-essential libtool autoconf automake cmake"
 RUN <<EOF


### PR DESCRIPTION
## 変更内容

- Debian Buster向けのAPTアーカイブミラー切り替え処理を削除
- Mirakurun 4.1.3のDebian Bookwormリポジトリをそのまま使用

## 原因

Renovate PR #36でベースイメージがMirakurun 4.1.3へ更新されましたが、DockerfileにはBuster向けの処理が残っていました。4.1.3では`/etc/apt/sources.list`が存在しないため、`sed`が失敗してDockerイメージをビルドできませんでした。

## 影響

Renovate PR #36の`mirakurun / check`がMirakurun 4.1.3で完走できるようになります。

## 検証

- `git diff --check`
- `docker build --progress=plain --tag home-server-infrastructure-docker-mirakurun-ci-fix:local src/mirakurun`